### PR TITLE
Fix

### DIFF
--- a/furnace/masking_generator.py
+++ b/furnace/masking_generator.py
@@ -53,7 +53,7 @@ class MaskingGenerator:
         return delta
 
     def __call__(self):
-        mask = np.zeros(shape=self.get_shape(), dtype=np.int)
+        mask = np.zeros(shape=self.get_shape(), dtype=int)
         mask_count = 0
         while mask_count != self.num_masking_patches:
             max_mask_patches = self.num_masking_patches - mask_count

--- a/models/modeling_discrete_vae.py
+++ b/models/modeling_discrete_vae.py
@@ -225,8 +225,8 @@ class Dalle_VAE(BasicVAE):
         self.image_size = image_size
 
     def load_model(self, model_dir, device):
-        self.encoder = load_model(os.path.join(model_dir, "encoder.pkl"), device)
-        self.decoder = load_model(os.path.join(model_dir, "decoder.pkl"), device)
+        self.encoder = load_model(os.path.join(model_dir, "encoder.pkl.1"), device)
+        self.decoder = load_model(os.path.join(model_dir, "decoder.pkl.1"), device)
 
     def decode(self, img_seq):
         bsz = img_seq.size()[0]

--- a/models/modeling_discrete_vae.py
+++ b/models/modeling_discrete_vae.py
@@ -225,8 +225,8 @@ class Dalle_VAE(BasicVAE):
         self.image_size = image_size
 
     def load_model(self, model_dir, device):
-        self.encoder = load_model(os.path.join(model_dir, "encoder.pkl.1"), device)
-        self.decoder = load_model(os.path.join(model_dir, "decoder.pkl.1"), device)
+        self.encoder = load_model(os.path.join(model_dir, "encoder.pkl"), device)
+        self.decoder = load_model(os.path.join(model_dir, "decoder.pkl"), device)
 
     def decode(self, img_seq):
         bsz = img_seq.size()[0]


### PR DESCRIPTION
This fix solve two problems:
- since numpy 1.20 np.int has been deprecated [link](https://numpy.org/doc/stable/release/1.20.0-notes.html#using-the-aliases-of-builtin-types-like-np-int-is-deprecated). Since a specific version of numpy is not specified in requirements this should fix it.
- when downloading dall-e tokenizer weight from  https://cdn.openai.com/dall-e/decoder.pkl you now download two files encoder.pkl.1 and encoder.pkl. It seems that the right one to load is  encoder.pkl.1